### PR TITLE
Initial support of StatsD

### DIFF
--- a/_build/debian/kandalf
+++ b/_build/debian/kandalf
@@ -44,7 +44,7 @@ case "$1" in
         ${0} start
         ;;
     reload)
-        cat $PIDFILE | xarg kill -SIGHUP
+        cat $PIDFILE | xargs kill -SIGHUP
         ;;
     *)
         echo "Usage: /etc/init.d/$NAME {start|stop|restart|reload}" >&2

--- a/_build/resources/config.yml
+++ b/_build/resources/config.yml
@@ -29,8 +29,6 @@ kafka:
   # The total number of times to retry sending a message.
   # Should be similar to the `message.send.max.retries` setting of the JVM producer.
   retry_max:            5
-rabbitmq:
-  url:                  "amqp://user:password@rmq"
 queue:
   # The pause between attempts to flush in-memory queue to kafka
   flush_timeout:        "5s"
@@ -43,3 +41,8 @@ queue:
     key_name:           "failed_messages"
     # The pause between attempts to flush content of `queue.redis.key_name` to kafka
     flush_timeout:      "10s"
+rabbitmq:
+  url:                  "amqp://user:password@rmq"
+statsd:
+  address:              ""
+  prefix:               "kandalf"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e590116c68cbba4a50a6067b45e895e7ee746c9ff58a28bf98638d4043722389
-updated: 2016-09-16T12:55:32.480912059+02:00
+hash: 23dd72cfbc85f3efade12646ed650ac4c9cc5db5af4d15ba19c8f7c3e4d070b9
+updated: 2016-09-21T10:38:41.204730962+02:00
 imports:
 - name: github.com/bshuster-repo/logrus-logstash-hook
   version: c5a17a5eb72da4c560f5e9bfb165180d9e681741
@@ -30,9 +30,11 @@ imports:
 - name: github.com/urfave/cli
   version: a14d7d367bc02b1f57d88de97926727f2d936387
 - name: golang.org/x/sys
-  version: 30de6d19a3bd89a5f38ae4028e23aaa5582648af
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
+- name: gopkg.in/alexcesaro/statsd.v2
+  version: 7fea3f0d2fab1ad973e641e51dba45443a311a90
 - name: gopkg.in/bsm/ratelimit.v1
   version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/natefinch/lumberjack.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,3 +14,5 @@ import:
 - package: gopkg.in/yaml.v2
 - package: gopkg.in/redis.v3
 - package: gopkg.in/natefinch/lumberjack.v2
+- package: gopkg.in/alexcesaro/statsd.v2
+  version: ^2.0.0

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"kandalf/config"
 	"kandalf/logger"
 	"kandalf/pipes"
+	"kandalf/statsd"
 	"kandalf/workers"
 )
 
@@ -90,6 +91,7 @@ func actionRun(ctx *cli.Context) error {
 
 // Reloads configuration and lists of available pipes
 func doReload(pConfig, pPipes string) {
-	config.Instance(pConfig)
+	cnf := config.Instance(pConfig)
 	_ = pipes.All(pPipes)
+	_ = statsd.Instance(cnf)
 }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -1,0 +1,58 @@
+package statsd
+
+import (
+	"sync"
+
+	"github.com/olebedev/config"
+	s "gopkg.in/alexcesaro/statsd.v2"
+
+	log "kandalf/logger"
+)
+
+var (
+	client *s.Client
+	err    error
+	mutex  *sync.Mutex = &sync.Mutex{}
+)
+
+// Returns the instance of StatsD client.
+// If the argument is provided, will try to reload client.
+func Instance(configs ...*config.Config) *s.Client {
+	if len(configs) > 0 {
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		if client != nil {
+			client.Close()
+		}
+
+		client, err = getClient(configs[0])
+		if err != nil {
+			log.Instance().
+				WithError(err).
+				Fatal("Unable to instantiate StatsD client")
+		}
+	}
+
+	return client
+}
+
+// Instantiates the client object.
+func getClient(c *config.Config) (*s.Client, error) {
+	var options []s.Option
+
+	address := c.UString("statsd.address", "")
+	prefix := c.UString("statsd.prefix", "")
+
+	if len(address) == 0 {
+		options = append(options, s.Mute(true))
+	} else {
+		options = append(options, s.Address(address))
+	}
+
+	if len(prefix) > 0 {
+		options = append(options, s.Prefix(prefix))
+	}
+
+	return s.New(options...)
+}

--- a/workers/producer.go
+++ b/workers/producer.go
@@ -5,6 +5,7 @@ import (
 
 	"kandalf/config"
 	"kandalf/logger"
+	"kandalf/statsd"
 )
 
 type internalProducer struct {
@@ -46,10 +47,14 @@ func (p *internalProducer) handleMessage(msg internalMessage) (err error) {
 	})
 
 	if err == nil {
+		statsd.Instance().Increment("kafka.new-messages")
+
 		logger.Instance().
 			WithField("topic", msg.Topic).
 			Debug("Successfully sent message to kafka")
 	} else {
+		statsd.Instance().Increment("kafka.failed-messages")
+
 		logger.Instance().
 			WithField("topic", msg.Topic).
 			Debug("An error occurred while sending message to kafka")

--- a/workers/worker.go
+++ b/workers/worker.go
@@ -109,12 +109,12 @@ func (w *Worker) doRun() {
 // Returns list of the internal workers
 func (w *Worker) getWorkers() (workers []internalWorker, err error) {
 	var (
-		c      *internalConsumer
-		q      *internalQueue
-		rmqUrl string
+		consumer *internalConsumer
+		queue    *internalQueue
+		rmqUrl   string
 	)
 
-	q, err = newInternalQueue()
+	queue, err = newInternalQueue()
 	if err != nil {
 		return nil, fmt.Errorf("An error occured while instantiating queue: %v", err)
 	}
@@ -125,13 +125,13 @@ func (w *Worker) getWorkers() (workers []internalWorker, err error) {
 	}
 
 	for _, pipe := range pipes.All() {
-		c, err = newInternalConsumer(rmqUrl, q, pipe)
+		consumer, err = newInternalConsumer(rmqUrl, queue, pipe)
 		if err != nil {
 			logger.Instance().
 				WithError(err).
 				Warning("Unable to create consumer")
 		} else {
-			workers = append(workers, c)
+			workers = append(workers, consumer)
 
 			logger.Instance().
 				WithError(err).
@@ -143,7 +143,7 @@ func (w *Worker) getWorkers() (workers []internalWorker, err error) {
 		return nil, errors.New("Haven't found any consumer or all of them failed to connect")
 	}
 
-	workers = append(workers, q)
+	workers = append(workers, queue)
 
 	return workers, nil
 }


### PR DESCRIPTION
This just fires following counters:
- **internal-queue.new-messages** when message consumed from RabbitMQ and put into internal queue;
- **redis.new-messages** when kafka is unavailable but message successfully stored in redis;
- **redis.failed-messages** when redis failed and message left in memory;
- **kafka.new-messages** when message successfully sent to kafka;
- **kafka.failed-messages** when kafka is unavailable and we have to store a message in redis or in the memory.
