### PR TITLE
PT-1562 Allow declaring non-durable exchanges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.10
+  - "1.10"
   - stable
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.x
+  - 1.10
+  - stable
 
 install:
   - mkdir -p $GOPATH/bin

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,14 +4,14 @@
 [[projects]]
   name = "github.com/Shopify/sarama"
   packages = ["."]
-  revision = "f7be6aa2bc7b2e38edf816b08b582782194a1c02"
-  version = "v1.16.0"
+  revision = "35324cf48e33d8260e1c7c18854465a904ade249"
+  version = "v1.17.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/TV4/logrus-stackdriver-formatter"
   packages = ["."]
-  revision = "5feb4e99b2603ed887bcd9e95d77e4115155db03"
+  revision = "4580df31bae116b734c17ffd155492461d5facb6"
+  version = "v0.1.0"
 
 [[projects]]
   name = "github.com/bshuster-repo/logrus-logstash-hook"
@@ -28,14 +28,14 @@
 [[projects]]
   name = "github.com/eapache/go-resiliency"
   packages = ["breaker"]
-  revision = "6800482f2c813e689c88b7ed3282262385011890"
-  version = "v1.0.0"
+  revision = "ea41b0fad31007accc7f806884dcdf3da98b79ce"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
-  revision = "bb955e01b9346ac19dc29eb16586c90ded99a98c"
+  revision = "040cc1a32f578808623071247fdbd5cc43f37f5f"
 
 [[projects]]
   name = "github.com/eapache/queue"
@@ -74,7 +74,7 @@
   branch = "master"
   name = "github.com/golang/snappy"
   packages = ["."]
-  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
   branch = "master"
@@ -91,13 +91,13 @@
     "json/scanner",
     "json/token"
   ]
-  revision = "f40e974e75af4e271d97ce0fc917af5898ae7bda"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   name = "github.com/hellofresh/logging-go"
   packages = ["."]
-  revision = "ef4f31673723710ae856518f1874aa1a28b41341"
-  version = "v0.2.0"
+  revision = "4912379b996a90083d0c5e63d24bac471f16e342"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/hellofresh/stats-go"
@@ -111,8 +111,8 @@
     "state",
     "timer"
   ]
-  revision = "0627c498c8cf525b2622b13a8c71431714a44243"
-  version = "v0.6.3"
+  revision = "2217eefe1ccbabac7dc9d6e040c8fd2b79dd022f"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -129,32 +129,29 @@
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
-  version = "v1.7.6"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
-  version = "v1.1.0"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/pierrec/lz4"
-  packages = ["."]
-  revision = "2fcda4cb7018ce05a25959d2fe08c83e3329f169"
-  version = "v1.1"
-
-[[projects]]
-  name = "github.com/pierrec/xxHash"
-  packages = ["xxHash32"]
-  revision = "f051bb7f1d1aaf1b5a665d74fb6b0217712c69f7"
-  version = "v0.1.1"
+  packages = [
+    ".",
+    "internal/xxh32"
+  ]
+  revision = "1958fd8fff7f115e79725b1288e0b878b3e06b00"
+  version = "v2.0.3"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -178,7 +175,7 @@
   branch = "master"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
-  revision = "8732c616f52954686704c8645fe1a9d59e9df7c1"
+  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -192,8 +189,8 @@
     ".",
     "hooks/syslog"
   ]
-  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
-  version = "v1.0.5"
+  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
+  version = "v1.0.6"
 
 [[projects]]
   name = "github.com/spf13/afero"
@@ -201,8 +198,8 @@
     ".",
     "mem"
   ]
-  revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
-  version = "v1.0.2"
+  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -213,8 +210,8 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
-  version = "v0.0.1"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   branch = "master"
@@ -225,8 +222,8 @@
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/spf13/viper"
@@ -238,7 +235,7 @@
   branch = "master"
   name = "github.com/streadway/amqp"
   packages = ["."]
-  revision = "8e4aba63da9fc5571e01c6a45dc809a58cbc5a68"
+  revision = "e5adc2ada8b8efff032bf61173a233d143e9318e"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -246,14 +243,14 @@
     "assert",
     "require"
   ]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "80db560fac1fb3e6ac81dbc7f8ae4c061f5257bd"
+  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
@@ -262,7 +259,7 @@
     "unix",
     "windows"
   ]
-  revision = "c488ab1dd8481ef762f96a79a9577c27825be697"
+  revision = "e072cadbbdc8dd3d3ffa82b8b4b9304c261d9311"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -292,12 +289,12 @@
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "93e01717bbd6f848e421407dc6b600861ff214627a59fa806981f4b14a4810f9"
+  inputs-digest = "d98c237293217fe376d970ab893a2a7a61e4f1509633e0d2cde257380942c5dc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/Shopify/sarama"
-  version = "1.16.0"
+  version = "1.17.0"
 
 [[constraint]]
   name = "github.com/garyburd/redigo"
@@ -35,11 +35,11 @@
 
 [[constraint]]
   name = "github.com/hellofresh/logging-go"
-  version = "0.2.0"
+  version = "0.3.0"
 
 [[constraint]]
   name = "github.com/hellofresh/stats-go"
-  version = "0.6.3"
+  version = "0.8.0"
 
 [[constraint]]
   name = "github.com/kelseyhightower/envconfig"
@@ -55,11 +55,11 @@
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "1.0.5"
+  version = "1.0.6"
 
 [[constraint]]
   name = "github.com/spf13/cobra"
-  version = "0.0.1"
+  version = "0.0.3"
 
 [[constraint]]
   name = "github.com/spf13/viper"
@@ -71,7 +71,7 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.1"
+  version = "1.2.2"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ deps:
 	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	@go get -u github.com/golang/dep/cmd/dep
 	@go get -u github.com/golang/lint/golint
-	@dep ensure
+	@dep ensure -v -vendor-only
 
 build:
 	@echo "$(OK_COLOR)==> Building... $(NO_COLOR)"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The rules, defining which messages should be send to which Kafka topics, are def
 ```yaml
 - kafkaTopic: "loyalty"                                # name of the topic in Kafka where message will be sent
   rabbitExchangeName: "customers"                      # name of the exchange in RabbitMQ
+  rabbitTransientExchange: false                       # determines if the exchange should be declared as durable or transient
   rabbitRoutingKey: "badge.received"                   # routing key for exchange
   rabbitQueueName: "kandalf-customers-badge.received"  # the name of RabbitMQ queue to read messages from
   rabbitDurableQueue: true                             # determines if the queue should be declared as durable

--- a/assets/pipes.yml
+++ b/assets/pipes.yml
@@ -9,6 +9,7 @@ pipes:
   rabbitQueueName: "kandalf-customers-order.created"
   rabbitDurableQueue: true
   rabbitAutoDeleteQueue: false
+  rabbitTransientExchange: false
 
 - kafkaTopic: "loyalty"
   rabbitExchangeName: "customers"
@@ -16,6 +17,7 @@ pipes:
   rabbitQueueName: "kandalf-customers-badge.received"
   rabbitDurableQueue: false
   rabbitAutoDeleteQueue: true
+  rabbitTransientExchange: true
 
 - kafkaTopic: "topic_for_several_events"
   rabbitExchangeName: "users"
@@ -26,3 +28,4 @@ pipes:
   rabbitQueueName: "kandalf-users.user.registered"
   rabbitDurableQueue: true
   rabbitAutoDeleteQueue: false
+  rabbitTransientExchange: false

--- a/assets/pipes.yml
+++ b/assets/pipes.yml
@@ -29,3 +29,10 @@ pipes:
   rabbitDurableQueue: true
   rabbitAutoDeleteQueue: false
   rabbitTransientExchange: false
+
+- kafkaTopic: "missing.transient.exchange"
+  rabbitExchangeName: "customers"
+  rabbitRoutingKey: "badge.received"
+  rabbitQueueName: "kandalf-customers-badge.received"
+  rabbitDurableQueue: false
+  rabbitAutoDeleteQueue: true

--- a/pkg/amqp/handler.go
+++ b/pkg/amqp/handler.go
@@ -32,7 +32,15 @@ func NewQueuesHandler(pipes []config.Pipe, handler MessageHandler, statsClient c
 
 		for _, pipe := range pipes {
 			operation = bucket.MetricOperation{statsOpConnect, "exchange", pipe.RabbitExchangeName}
-			err = channel.ExchangeDeclare(pipe.RabbitExchangeName, exchangeTypeTopic, true, false, false, false, nil)
+			err = channel.ExchangeDeclare(
+				pipe.RabbitExchangeName,
+				exchangeTypeTopic,
+				!pipe.RabbitTransientExchange,
+				false,
+				false,
+				false,
+				nil,
+			)
 			statsClient.TrackOperation(statsAMQPSection, operation, nil, nil == err)
 			if err != nil {
 				log.WithError(err).Error("Failed to declare exchange")

--- a/pkg/config/pipes.go
+++ b/pkg/config/pipes.go
@@ -8,12 +8,13 @@ import (
 
 // Pipe contains settings for single bridge pipe between Kafka and RabbitMQ
 type Pipe struct {
-	KafkaTopic            string
-	RabbitExchangeName    string
-	RabbitRoutingKey      []string
-	RabbitQueueName       string
-	RabbitDurableQueue    bool
-	RabbitAutoDeleteQueue bool
+	KafkaTopic              string
+	RabbitExchangeName      string
+	RabbitTransientExchange bool
+	RabbitRoutingKey        []string
+	RabbitQueueName         string
+	RabbitDurableQueue      bool
+	RabbitAutoDeleteQueue   bool
 }
 
 func (p Pipe) String() string {

--- a/pkg/config/pipes_test.go
+++ b/pkg/config/pipes_test.go
@@ -17,6 +17,7 @@ func assertPipes(t *testing.T, pipes []Pipe) {
 	assert.Equal(t, "kandalf-customers-order.created", pipes[0].RabbitQueueName)
 	assert.Equal(t, true, pipes[0].RabbitDurableQueue)
 	assert.Equal(t, false, pipes[0].RabbitAutoDeleteQueue)
+	assert.Equal(t, false, pipes[0].RabbitTransientExchange)
 
 	assert.Equal(t, "customers", pipes[1].RabbitExchangeName)
 	assert.Equal(t, []string{"badge.received"}, pipes[1].RabbitRoutingKey)
@@ -24,6 +25,7 @@ func assertPipes(t *testing.T, pipes []Pipe) {
 	assert.Equal(t, "kandalf-customers-badge.received", pipes[1].RabbitQueueName)
 	assert.Equal(t, false, pipes[1].RabbitDurableQueue)
 	assert.Equal(t, true, pipes[1].RabbitAutoDeleteQueue)
+	assert.Equal(t, true, pipes[1].RabbitTransientExchange)
 
 	assert.Equal(t, "users", pipes[2].RabbitExchangeName)
 	assert.Equal(t, []string{"user.de.registered", "user.at.registered", "user.ch.registered"}, pipes[2].RabbitRoutingKey)
@@ -31,6 +33,7 @@ func assertPipes(t *testing.T, pipes []Pipe) {
 	assert.Equal(t, "kandalf-users.user.registered", pipes[2].RabbitQueueName)
 	assert.Equal(t, true, pipes[2].RabbitDurableQueue)
 	assert.Equal(t, false, pipes[2].RabbitAutoDeleteQueue)
+	assert.Equal(t, false, pipes[2].RabbitTransientExchange)
 }
 
 func TestLoadPipesFromFile(t *testing.T) {
@@ -76,14 +79,15 @@ func TestLoadPipesFromFile_Error(t *testing.T) {
 
 func TestPipe_String(t *testing.T) {
 	pipe := Pipe{
-		KafkaTopic:            "topic",
-		RabbitExchangeName:    "rqExchange",
-		RabbitRoutingKey:      []string{"rqKey"},
-		RabbitQueueName:       "rqQueue",
-		RabbitDurableQueue:    true,
-		RabbitAutoDeleteQueue: false,
+		KafkaTopic:              "topic",
+		RabbitExchangeName:      "rqExchange",
+		RabbitRoutingKey:        []string{"rqKey"},
+		RabbitQueueName:         "rqQueue",
+		RabbitDurableQueue:      true,
+		RabbitAutoDeleteQueue:   false,
+		RabbitTransientExchange: false,
 	}
-	pipeJSON := `{"KafkaTopic":"topic","RabbitExchangeName":"rqExchange","RabbitRoutingKey":["rqKey"],"RabbitQueueName":"rqQueue","RabbitDurableQueue":true,"RabbitAutoDeleteQueue":false}`
+	pipeJSON := `{"KafkaTopic":"topic","RabbitExchangeName":"rqExchange","RabbitRoutingKey":["rqKey"],"RabbitQueueName":"rqQueue","RabbitDurableQueue":true,"RabbitAutoDeleteQueue":false,"RabbitTransientExchange":false}`
 
 	assert.Equal(t, pipeJSON, pipe.String())
 	assert.Equal(t, pipeJSON, fmt.Sprintf("%s", pipe))

--- a/pkg/config/pipes_test.go
+++ b/pkg/config/pipes_test.go
@@ -34,6 +34,9 @@ func assertPipes(t *testing.T, pipes []Pipe) {
 	assert.Equal(t, true, pipes[2].RabbitDurableQueue)
 	assert.Equal(t, false, pipes[2].RabbitAutoDeleteQueue)
 	assert.Equal(t, false, pipes[2].RabbitTransientExchange)
+
+	assert.Equal(t, "missing.transient.exchange", pipes[3].KafkaTopic)
+	assert.Equal(t, false, pipes[3].RabbitTransientExchange)
 }
 
 func TestLoadPipesFromFile(t *testing.T) {
@@ -48,7 +51,7 @@ func TestLoadPipesFromFile(t *testing.T) {
 
 	pipes, err := LoadPipesFromFile(pipesPath)
 	require.NoError(t, err)
-	assert.Len(t, pipes, 3)
+	assert.Len(t, pipes, 4)
 
 	assertPipes(t, pipes)
 }
@@ -81,13 +84,13 @@ func TestPipe_String(t *testing.T) {
 	pipe := Pipe{
 		KafkaTopic:              "topic",
 		RabbitExchangeName:      "rqExchange",
+		RabbitTransientExchange: false,
 		RabbitRoutingKey:        []string{"rqKey"},
 		RabbitQueueName:         "rqQueue",
 		RabbitDurableQueue:      true,
 		RabbitAutoDeleteQueue:   false,
-		RabbitTransientExchange: false,
 	}
-	pipeJSON := `{"KafkaTopic":"topic","RabbitExchangeName":"rqExchange","RabbitRoutingKey":["rqKey"],"RabbitQueueName":"rqQueue","RabbitDurableQueue":true,"RabbitAutoDeleteQueue":false,"RabbitTransientExchange":false}`
+	pipeJSON := `{"KafkaTopic":"topic","RabbitExchangeName":"rqExchange","RabbitTransientExchange":false,"RabbitRoutingKey":["rqKey"],"RabbitQueueName":"rqQueue","RabbitDurableQueue":true,"RabbitAutoDeleteQueue":false}`
 
 	assert.Equal(t, pipeJSON, pipe.String())
 	assert.Equal(t, pipeJSON, fmt.Sprintf("%s", pipe))


### PR DESCRIPTION
# What this PR changes:
Added `rabbitTransientExchange` property to pipe definition to declare transient (non-durable) exchanges.

Property is called in this way, not the `rabbitDurableExchange`, because of the default golang bool value for BC compatibility - in the current stabel version exchange is always declared as `durable`, so old pipes configs missing this new property will remain `non-transient`.

PS: additionally bumped all the dependencies to the latest stabe verisons

Refs https://github.com/hellofresh/kandalf/issues/35