### PR TITLE
update repo path of golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: clean deps build
 deps:
 	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	@go get -u github.com/golang/dep/cmd/dep
-	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint/golint
 	@dep ensure -v -vendor-only
 
 build:


### PR DESCRIPTION
# What this PR changes:
- Repo path for golint, current path no longer works with current version of go
Please see [here](https://github.com/golang/lint/issues/415) for more info

