### PR TITLE
Removed links to code docs as we do not need it actually

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,3 @@ For production you can use minimalistic prebuilt [hellofresh/kandalf](https://qu
 ## Contributing
 
 To start contributing, please check [CONTRIBUTING](CONTRIBUTING.md).
-
-## Documentation
-
-* Kandalf Go Docs: https://godoc.org/github.com/hellofresh/kandalf
-* Go lang: https://golang.org/


### PR DESCRIPTION
# What this PR changes:
This is not a library and it does not expose any publicly available code, so there is no need for a link to code documentation.

Fixes https://github.com/hellofresh/kandalf/issues/52 - motivation for this described there also.