### PR TITLE
EES-3753 Docker username is not a secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          DOCKER_USERNAME: "hellofreshtech"
+          DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
No need to hide username - it is not secret, otherwise pipeline runner replaces part of the docker image name with `***`