### PR TITLE
EES-3753 Use built-in cobra version parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -11,24 +9,16 @@ import (
 )
 
 var (
-	version     string
-	configPath  string
-	versionFlag bool
+	version    string
+	configPath string
 )
 
 func main() {
-	versionString := "Kandalf v" + version
-	cobra.OnInitialize(func() {
-		if versionFlag {
-			fmt.Println(versionString)
-			os.Exit(0)
-		}
-	})
-
 	var RootCmd = &cobra.Command{
-		Use:   "kandalf",
-		Short: versionString,
-		Long: versionString + `. RabbitMQ to Kafka bridge.
+		Use:     "kandalf",
+		Version: version,
+		Short:   `RabbitMQ to Kafka bridge.`,
+		Long: `RabbitMQ to Kafka bridge.
 
 Complete documentation is available at https://github.com/hellofresh/kandalf`,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -36,7 +26,6 @@ Complete documentation is available at https://github.com/hellofresh/kandalf`,
 		},
 	}
 	RootCmd.Flags().StringVarP(&configPath, "config", "c", "", "Source of a configuration file")
-	RootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "Print application version")
 
 	err := RootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
No need to reinvent the wheel. Probably parameter was not available when the app was first created, but now it is.