### PR TITLE
Use hellofresh DockerHub organization

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           version: v1.30
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,8 +27,8 @@ dockers:
     binaries:
       - kandalf
     image_templates:
-      - "hellofreshtech/kandalf:latest"
-      - "hellofreshtech/kandalf:{{.Tag}}"
+      - "hellofresh/kandalf:latest"
+      - "hellofresh/kandalf:{{.Tag}}"
     dockerfile: Dockerfile
     extra_files:
       - assets/pipes.yml


### PR DESCRIPTION
This PR changes DockerHub target to official [hellofresh](https://hub.docker.com/u/hellofresh) organization.