### PR TITLE
Fixed url to docker hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can find sample Kafka Pipes Config file in [assets/pipes.yml](./assets/pipes
 
 For testing and development you can use [`docker-compose`](./docker-compose.yml) file with all the required services.
 
-For production you can use minimalistic prebuilt [hellofreshtech/kandalf](https://hub.docker.com/r/hellofreshtech/kandalf/tags) image as base image or mount pipes configuration volume to `/etc/kandalf/conf/`.
+For production you can use minimalistic prebuilt [hellofresh/kandalf](https://hub.docker.com/r/hellofresh/kandalf/tags) image as base image or mount pipes configuration volume to `/etc/kandalf/conf/`.
 
 ## Todo
 


### PR DESCRIPTION
Using the docker hub link in the readme leads to 404 not found page.